### PR TITLE
Support for newer Robotframework versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-robotframework==3.2.1
+robotframework>=3.2.1
 confluent-kafka==1.5.0
 uuid==1.30

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(name         = 'robotframework-confluentkafkalibrary',
           "Topic :: Software Development :: Testing"
       ],
       install_requires = [
-          'robotframework == 3.2.1',
+          'robotframework >= 3.2.1',
           'confluent-kafka == 1.5.0',
           'uuid==1.30',
       ],


### PR DESCRIPTION
RF 3.2.2 came out a month ago, but the library is regretfully fixed at 3.2.1. 
Skimming through the code, the only dependency is `BuiltIn.set_global_variable()`, which doesn't look is changing in the 4.0 version - e.g. there shouldn't be unexpected side effects.