### PR TITLE
close admin method

### DIFF
--- a/src/ConfluentKafkaLibrary/admin_client.py
+++ b/src/ConfluentKafkaLibrary/admin_client.py
@@ -231,3 +231,9 @@ class KafkaAdminClient():
             except (TypeError, ValueError ) as e:
                 return f"Invalid input: {e}"
         return config_results
+
+    def close_admin(self, group_id):
+        """Close down and terminate the Kafka Admin.
+        """
+        # simply deleting client will close connection
+        del self.admin_clients[group_id]


### PR DESCRIPTION
Closes [issue 49](https://github.com/robooo/robotframework-ConfluentKafkaLibrary/issues/49). 

Tested with following scenario:
- start kafka docker container
- run Robot test that uses Admin Client
- call new `Close Admin` keyword
- stop kafka container before Robot FW unloads
- observe Robot output

No more `%6|1718006260.036|FAIL|rdkafka#producer-1|` error messages in stderr.